### PR TITLE
re-write async iters for python 3.5

### DIFF
--- a/ssb/muxrpc.py
+++ b/ssb/muxrpc.py
@@ -28,11 +28,14 @@ class MuxRPCSourceHandler(MuxRPCHandler):
     def __init__(self, ps_handler):
         self.ps_handler = ps_handler
 
-    async def __aiter__(self):
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
         async for msg in self.ps_handler:
             try:
                 self.check_message(msg)
-                yield msg
+                return msg
             except MuxRPCAPIException:
                 raise
 


### PR DESCRIPTION
This is an attempt to make the code run on python 3.5. I used the following document:

https://www.python.org/dev/peps/pep-0492/#asynchronous-iterators-and-async-for