### PR TITLE
Specify pynacl==1.1.2

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,5 +1,5 @@
 colorlog
-pynacl
+pynacl==1.1.2
 pyyaml
 secret-handshake
 simplejson


### PR DESCRIPTION
Previously, this was throwing an error:

> secret-handshake 0.1.0.dev3 has requirement pynacl==1.1.2, but you'll have pynacl 1.3.0 which is incompatible.